### PR TITLE
Allow zero or more matches, lazy capture and name arranging

### DIFF
--- a/mod_papers/helper.php
+++ b/mod_papers/helper.php
@@ -46,6 +46,15 @@ class ModPapersHelper
         return $papers;
     }
 
+    private function name($author) {
+        $names = explode(", ", $author);
+        if (count($names) > 1) {
+            return $names[1] . ' ' . $names[0];
+        } else {
+            return $names[0];
+        }
+    }
+
     private function getPapers($orcids, $cutoff_year)
     {
         // create a new cURL resource
@@ -173,50 +182,47 @@ class ModPapersHelper
                 $output .= "<br><h2>" . $curr_year . "</h2>";
             }
             $output .= '<b>' . $work['title']['title']['value'] . '</b><br>';
-
             if (strcmp($work['citation']['citation-type'], 'BIBTEX') == 0) {
                 $bibtex = $work['citation']['citation-value'];
                 $volume = '';
                 $pages  = '';
-                if (preg_match('/volume\\s?=\\s?{(\\d+)}/', $bibtex, $match)) {
+                if (preg_match('/volume\\s*=\\s*{(\\d+)}/', $bibtex, $match)) {
                     $volume = $match[1];
                 }
-                if (preg_match('/pages\\s?=\\s?{([0-9-]+)}/', $bibtex, $match)) {
+                if (preg_match('/pages\\s*=\\s*{([0-9-]+)}/', $bibtex, $match)) {
                     $pages = $match[1];
                 }
             }
-
-            if (!is_null($work['contributors'])) {
+            if (!is_null($work['contributors']) && array_filter($work['contributors']['contributor'])) {
                 foreach ($work['contributors']['contributor'] as $authors) {
                     if (($authors === reset($work['contributors']['contributor'])) && ($authors === end($work['contributors']['contributor']))) {
-                        $output .= $authors['credit-name']['value'] . '<br>';
+                        $output .= name($authors['credit-name']['value']) . '<br>';
                     } elseif ($authors === reset($work['contributors']['contributor'])) {
-                        $output .= $authors['credit-name']['value'];
+                        $output .= name($authors['credit-name']['value']);
                     } elseif ($authors === end($work['contributors']['contributor'])) {
-                        $output .= ' and ' . $authors['credit-name']['value'] . '<br>';
+                        $output .= ' and ' . name($authors['credit-name']['value']) . '<br>';
                     } else {
-                        $output .= ', ' . $authors['credit-name']['value'];
+                        $output .= ', ' . name($authors['credit-name']['value']);
                     }
                 }
             } else {
                 //Get authorlist from bibtex
-                if (preg_match('/author\\s?=\\s?{(.+)}/', $bibtex, $match)) {
+                if (preg_match('/author\\s*=\\s*{(.+)}/U', $bibtex, $match)) {
                     $authorstr = $match[1];
                     $authors   = explode(" and ", $authorstr);
                     foreach ($authors as $author) {
                         if (($author === reset($authors)) && ($author === end($authors))) {
-                            $output .= $author . '<br>';
+                            $output .= name($author) . '<br>';
                         } elseif ($author === reset($authors)) {
-                            $output .= $author;
+                            $output .= name($author);
                         } elseif ($author === end($authors)) {
-                            $output .= ' and ' . $author . '<br>';
+                            $output .= ' and ' . name($author) . '<br>';
                         } else {
-                            $output .= ', ' . $author;
+                            $output .= ', ' . name($author);
                         }
                     }
                 }
             }
-
             if (is_array($work['external-ids']['external-id'])) {
                 foreach ($work['external-ids']['external-id'] as $ids) {
                     if (strcmp($ids['external-id-type'], 'doi') == 0) {

--- a/mod_papers/helper.php
+++ b/mod_papers/helper.php
@@ -196,13 +196,13 @@ class ModPapersHelper
             if (!is_null($work['contributors']) && array_filter($work['contributors']['contributor'])) {
                 foreach ($work['contributors']['contributor'] as $authors) {
                     if (($authors === reset($work['contributors']['contributor'])) && ($authors === end($work['contributors']['contributor']))) {
-                        $output .= name($authors['credit-name']['value']) . '<br>';
+                        $output .= self::name($authors['credit-name']['value']) . '<br>';
                     } elseif ($authors === reset($work['contributors']['contributor'])) {
-                        $output .= name($authors['credit-name']['value']);
+                        $output .= self::name($authors['credit-name']['value']);
                     } elseif ($authors === end($work['contributors']['contributor'])) {
-                        $output .= ' and ' . name($authors['credit-name']['value']) . '<br>';
+                        $output .= ' and ' . self::name($authors['credit-name']['value']) . '<br>';
                     } else {
-                        $output .= ', ' . name($authors['credit-name']['value']);
+                        $output .= ', ' . self::name($authors['credit-name']['value']);
                     }
                 }
             } else {
@@ -212,13 +212,13 @@ class ModPapersHelper
                     $authors   = explode(" and ", $authorstr);
                     foreach ($authors as $author) {
                         if (($author === reset($authors)) && ($author === end($authors))) {
-                            $output .= name($author) . '<br>';
+                            $output .= self::name($author) . '<br>';
                         } elseif ($author === reset($authors)) {
-                            $output .= name($author);
+                            $output .= self::name($author);
                         } elseif ($author === end($authors)) {
-                            $output .= ' and ' . name($author) . '<br>';
+                            $output .= ' and ' . self::name($author) . '<br>';
                         } else {
-                            $output .= ', ' . name($author);
+                            $output .= ', ' . self::name($author);
                         }
                     }
                 }


### PR DESCRIPTION
Working on solutions to #6.

A number of the issues there are due to ways the bibtex data is handled. Herein the following fixes have been implemented:

1. Modify regex parsers to allow *0 or more* matching so `volume  =` AND `volume =` AND `volume=` match.
2. Author list quantifiers are ungreedy such that poorly formed bibtex strings with newlines smashed into the next line (e.g. `}, \ntitle=`) can be parsed correctly.
3. The `names` function, which arranges first & last names a bit better than previous.

This fixes all the 'recent' problems in #6.