### PR TITLE
Better volume and page handling

### DIFF
--- a/mod_papers/helper.php
+++ b/mod_papers/helper.php
@@ -190,7 +190,12 @@ class ModPapersHelper
                     $volume = $match[1];
                 }
                 if (preg_match('/pages\\s*=\\s*{([0-9-]+)}/', $bibtex, $match)) {
-                    $pages = $match[1];
+                    $pageset = array_values(array_filter(explode("-", $match[1])));
+                    if (count($pageset) > 1) {
+                        $pages = $pageset[0] . '&ndash;' . $pageset[1];
+                    } else {
+                        $pages = $pageset[0];
+                    }
                 }
             }
             if (!is_null($work['contributors']) && array_filter($work['contributors']['contributor'])) {

--- a/mod_papers/helper.php
+++ b/mod_papers/helper.php
@@ -40,7 +40,7 @@ class ModPapersHelper
             fwrite($myfile, $papers);
             fclose($myfile);
         } else {
-            $papers = file_get_contents($data_file);	
+            $papers = file_get_contents($data_file);
         }
 
         return $papers;
@@ -182,10 +182,10 @@ class ModPapersHelper
                 $output .= "<br><h2>" . $curr_year . "</h2>";
             }
             $output .= '<b>' . $work['title']['title']['value'] . '</b><br>';
+            $volume = '';
+            $pages  = '';
             if (strcmp($work['citation']['citation-type'], 'BIBTEX') == 0) {
                 $bibtex = $work['citation']['citation-value'];
-                $volume = '';
-                $pages  = '';
                 if (preg_match('/volume\\s*=\\s*{(\\d+)}/', $bibtex, $match)) {
                     $volume = $match[1];
                 }


### PR DESCRIPTION
Fixes #9, as well as improves upon visualisation.

The issue in #9 is that OrcID has no volume or page data at all, meaning we **must** obtain them from bibtex. Previously we were assuming that this exists, now we don't. If this data is unavailable it's a graceful failure. 

Pages now have an en-dash separator if they use one, and this is handled for bibtex cases `1-2` and `1--2`.